### PR TITLE
Fix GetFullSql for stored procs

### DIFF
--- a/MichaelKappel.Repositories.SqlRepositoryBase.Tests/GetFullSql_Tests.cs
+++ b/MichaelKappel.Repositories.SqlRepositoryBase.Tests/GetFullSql_Tests.cs
@@ -1,0 +1,42 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Data.SqlClient;
+using System.Data;
+using MichaelKappel.Repository.Bases;
+
+namespace MichaelKappel.Repositories.SqlRepositoryBase.Tests
+{
+    public class TestRepo : SqlRepositoryBase<object>
+    {
+        public TestRepo() : base("server=(local);database=Test;trusted_connection=true;")
+        {
+        }
+
+        protected override object CreateInfoFromReader(SqlDataReader reader)
+        {
+            return new object();
+        }
+
+        public string CallGetFullSql(string sql, CommandType commandType, params SqlParameter[] parameters)
+        {
+            return this.GetFullSql(sql, commandType, parameters);
+        }
+    }
+
+    [TestClass]
+    public class GetFullSql_Tests
+    {
+        [TestMethod]
+        public void StoredProcedure_AddsExecAndParameters()
+        {
+            var repo = new TestRepo();
+            var p = new SqlParameter("@Id", SqlDbType.Int) { Value = 5 };
+
+            string actual = repo.CallGetFullSql("dbo.MyProc", CommandType.StoredProcedure, p).Trim();
+
+            string expected = "DECLARE @Id AS Int = 5;\r\nEXEC dbo.MyProc @Id = @Id";
+
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- require a `CommandType` parameter when generating the full SQL statement
- update GetFullSql implementation to use the provided `CommandType`
- adjust unit tests for new method signature

## Testing
- `dotnet test --verbosity normal` *(fails: .NET 9.0 SDK not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6883b8196cd8832fa62abdc3134d8476